### PR TITLE
Update devDependencies & minor tweaks

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,13 +1,13 @@
 {
+  "boss": true,
   "curly": true,
   "eqeqeq": true,
   "immed": true,
   "latedef": true,
   "newcap": true,
   "noarg": true,
-  "sub": true,
+  "node": true,
+  "strict": true,
   "undef": true,
-  "boss": true,
-  "eqnull": true,
-  "node": true
+  "unused": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,12 +52,12 @@ module.exports = function(grunt) {
   });
 
   grunt.loadTasks('tasks');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
   // Run stamp twice to make sure it's idempotent
-  grunt.registerTask('test', ['clean', 'copy', 'stamp', 'stamp', 'nodeunit']);
-  grunt.registerTask('default', ['jshint', 'test']);
+  grunt.registerTask('test', ['jshint', 'clean', 'copy', 'stamp', 'nodeunit']);
+  grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -14,13 +14,8 @@
   "bugs": {
     "url": "https://github.com/brainkim/grunt-stamp/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/brainkim/grunt-stamp/blob/master/LICENSE-MIT"
-    }
-  ],
-  "main": "Gruntfile.js",
+  "license": "MIT",
+  "main": "tasks/stamp.js",
   "engines": {
     "node": ">= 0.8.0"
   },
@@ -28,16 +23,19 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-nodeunit": "~0.2.0"
+    "grunt": "~1.0.1",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"
+  ],
+  "files": [
+    "tasks"
   ]
 }

--- a/test/stamp_test.js
+++ b/test/stamp_test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var grunt = require('grunt');
-
 /*
   ======== A Handy Little Nodeunit Reference ========
   https://github.com/caolan/nodeunit
@@ -21,10 +19,8 @@ var grunt = require('grunt');
     test.doesNotThrow(block, [error], [message])
     test.ifError(value)
 */
-function log(str) {
-  console.log(str);
-  return str;
-}
+
+var grunt = require('grunt');
 
 exports.stamp = {
   testdir: function(test) {


### PR DESCRIPTION
I still don't get why on Windows things break.

@vladikoff: doesn't `grunt.util.linefeed` work on Windows? This code fails for me https://github.com/brainkim/grunt-stamp/blob/master/tasks/stamp.js#L36